### PR TITLE
use class instead of dict for structure field names

### DIFF
--- a/mathlib_data_structures.py
+++ b/mathlib_data_structures.py
@@ -1,10 +1,9 @@
-mathlibStructures = dict(
-  DECLARATIONS = 'decls',
-  TACTICS = 'tactic_docs',
-  MODULE_DESCRIPTIONS = 'mod_docs',
-  NOTES = 'notes',
+class mathlibStructures:
+  DECLARATIONS = 'decls'
+  TACTICS = 'tactic_docs'
+  MODULE_DESCRIPTIONS = 'mod_docs'
+  NOTES = 'notes'
   INSTANCES = 'instances'
-)
 
 declaration = dict(
   NAME = 'name',
@@ -58,3 +57,5 @@ generalPages = dict(
   HOLE_COMMANDS = 'hole_commands',
   ATTRIBUTES = 'notes',
 )
+
+

--- a/mathlib_data_structures.py
+++ b/mathlib_data_structures.py
@@ -1,5 +1,5 @@
 mathlibStructures = dict(
-  DECLARATIONS = 'decl',
+  DECLARATIONS = 'decls',
   TACTICS = 'tactic_docs',
   MODULE_DESCRIPTIONS = 'mod_docs',
   NOTES = 'notes',

--- a/print_docs.py
+++ b/print_docs.py
@@ -111,20 +111,20 @@ def read_src_data():
   with open('export.json', 'r', encoding='utf-8') as f:
     lib_data = json.load(f, strict=False)
 
-  file_map, loc_map = separate_results(lib_data[mathlibStructures['DECLARATIONS']])
+  file_map, loc_map = separate_results(lib_data[mathlibStructures.DECLARATIONS])
 
-  for entry in lib_data[mathlibStructures['TACTICS']]:
+  for entry in lib_data[mathlibStructures.TACTICS]:
     if len(entry[tactic['TAGS']]) == 0:
       entry[tactic['TAGS']] = ['untagged']
 
-  mod_docs = {ImportName.of(f): docs for f, docs in lib_data[mathlibStructures['MODULE_DESCRIPTIONS']].items()}
+  mod_docs = {ImportName.of(f): docs for f, docs in lib_data[mathlibStructures.MODULE_DESCRIPTIONS].items()}
   # ensure the key is present for `default.lean` modules with no declarations
   for i_name in mod_docs:
     if i_name.project == '.':
       continue  # this is doc-gen itself
     file_map[i_name]
 
-  return file_map, loc_map, lib_data[mathlibStructures['NOTES']], mod_docs, lib_data[mathlibStructures['INSTANCES']], lib_data[mathlibStructures['TACTICS']]
+  return file_map, loc_map, lib_data[mathlibStructures.NOTES], mod_docs, lib_data[mathlibStructures.INSTANCES], lib_data[mathlibStructures.TACTICS]
 
 # ------------------------------------------------ END read source files -----------------------------------------------------
 

--- a/print_docs.py
+++ b/print_docs.py
@@ -211,8 +211,8 @@ def kind_of_decl(decl):
     return declarationKindsDestination['INDUCTIVE']
   elif decl[declaration['KIND']] == declarationKindsSource['THEOREM']: 
     return declarationKindsDestination['THEOREM']
-  elif decl[declaration['KIND']] == declarationKindsSource['CONSTANT']:
-    return declarationKindsDestination['CONSTANT']
+  elif decl[declaration['KIND']] == declarationKindsSource['CONST']:
+    return declarationKindsDestination['CONST']
   elif decl[declaration['KIND']] == declarationKindsSource['AXIOM']:
     return declarationKindsDestination['AXIOM']
 


### PR DESCRIPTION
This way pylint will notice if you accidentally use the wrong key.
I'm not sure if this is officially "pythonic".

It seems like more could be done translating the json to actual data structures with named fields; then these lookup tables wouldn't be necessary!
But this might be a lot of work for little gain.